### PR TITLE
Update gulp release task

### DIFF
--- a/config/gulp/release.js
+++ b/config/gulp/release.js
@@ -115,10 +115,11 @@ gulp.task('release:process', function () {
 
   var files = streamExtensions.map(function (extension) {
     var source = [
-      'Fonts\ and\ pairings/**/*.zip',
+      'Fonts/**/*.zip',
       '*.md',
       '**/*.pdf',
       // Ignore release process files
+      '!config/**/*',
       '!node_modules/**/*',
       '!.git/**/*',
       '!circle.yml',


### PR DESCRIPTION
This update makes it so that the `Fonts` folder is included and the `config` folder is excluded.

Fixes #38 